### PR TITLE
fix(mappings): more stable matching

### DIFF
--- a/wiremock/mappings/private/deposit/deposit_history_cc.json
+++ b/wiremock/mappings/private/deposit/deposit_history_cc.json
@@ -15,7 +15,7 @@
     },
     "queryParameters": {
       "asset": {
-        "matches": ".*"
+        "doesNotMatch": "jpy"
       }
     }
   },

--- a/wiremock/mappings/private/withdraw/withdrawal_history_cc.json
+++ b/wiremock/mappings/private/withdraw/withdrawal_history_cc.json
@@ -15,7 +15,7 @@
     },
     "queryParameters": {
       "asset": {
-        "matches": ".*"
+        "doesNotMatch": "jpy"
       }
     }
   },


### PR DESCRIPTION
It seems multiple matching mapping cause instability on some testing environment.
Using doesNotMatch satisfies both "asset" parameter is required and not multiple matching.